### PR TITLE
switch to pulse format if alsa format not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ X Window Recording Tool
 
 ffmpeg configuration
 --------------------
-The ffmpeg configuration requires the following for xcorder to work properly:
-> --extra-libs=-lasound
-> --enable-x11grab
+The ffmpeg build configuration requires the following for xcorder to work properly:
+> `--extra-libs=-lasound` or `--enable-libpulse`
+
+and
+
+> `--enable-x11grab`

--- a/audio.py
+++ b/audio.py
@@ -22,17 +22,19 @@ class Audio(object):
         self._devices = list()
         self._device = Device()
 
-        libalsa = libpulse = False
-
-        args = 'ffmpeg -version | grep -o "libalsa\|libpulse"'
+        args = 'ffmpeg -formats -v 0'
         popen = subprocess.Popen(args, shell=True,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
+        alsa = pulse = False
         for line in popen.stdout:
             if "alsa" in line:
-                libalsa = True
+                alsa = True
             elif "pulse" in line:
-                libpulse = True
+                pulse = True
+
+        if not alsa and not pulse:
+            raise Exception("available ffmpeg installation have not lasound or libpulse enabled")
 
         args = 'pacmd list-sources'
         popen = subprocess.Popen(args, shell=True,
@@ -47,7 +49,7 @@ class Audio(object):
 
             elif line.startswith('device.api = '):
                 api = line.split('=', 1)[1].strip().strip('"')
-                if api == "alsa" and not libalsa and libpulse:
+                if api == "alsa" and not alsa:
                     api = "pulse"
                 device.api = api
 

--- a/exporter.py
+++ b/exporter.py
@@ -15,6 +15,9 @@ import subprocess
 # =============================================================================
 # CLASSES
 # =============================================================================
+import os
+
+
 class Exporter(object):
 
     # =========================================================================
@@ -54,7 +57,7 @@ class Exporter(object):
 
         with open(self.fileList, 'w') as fileList:
             for segmentFile in segmentFiles:
-                fileList.write("file '{f}'\n".format(f=segmentFile))
+                fileList.write("file '{f}'\n".format(f=os.path.basename(segmentFile)))
 
     # =========================================================================
     @property
@@ -67,7 +70,6 @@ class Exporter(object):
     def optionArgs(self):
 
         return '-f concat ' + \
-               '-safe 0 ' \
                '-i {i} '.format(i=self.fileList) + \
                '-codec copy ' + \
                '-y ' + \

--- a/exporter.py
+++ b/exporter.py
@@ -27,6 +27,7 @@ class Exporter(object):
     # =========================================================================
     def start(self):
 
+        print self.args
         self.makeFileList()
         if not self._proc:
             self._proc = subprocess.Popen(self.args, shell=True,
@@ -66,6 +67,7 @@ class Exporter(object):
     def optionArgs(self):
 
         return '-f concat ' + \
+               '-safe 0 ' \
                '-i {i} '.format(i=self.fileList) + \
                '-codec copy ' + \
                '-y ' + \

--- a/xcorder
+++ b/xcorder
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/bin/env python2
 # =============================================================================
 # Module: xcorder
 # Contacts: Edward Li (drawdeil@gmail.com)


### PR DESCRIPTION
I tried to use this application on my laptop with Fedora26 installed. It so happens that the `ffmpeg` package that Fedora provides have the `libasound` (alsa format) not enabled. Someone can do a custom build of the ffmpeg but that requires the user to be a superuser. Why just not using what is available?

This commit is useful only for similar systems. So probably not worth to merge at this moment.